### PR TITLE
Fix Loggin Issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 		<scala.version>2.10.4</scala.version>
 		<scalatest.version>2.2.4</scalatest.version>
 		<spark.version>1.6.0</spark.version>
+		<log4j.version>2.0</log4j.version>
 	</properties>
 
 	<scm>
@@ -101,6 +102,11 @@
 			<artifactId>hadoop-client</artifactId>
 			<version>${hadoop.version}</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-1.2-api</artifactId>
+			<version>${log4j.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,6 +1,6 @@
-log4j.rootCategory=OFF, console
+log4j.rootCategory=INFO, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss.SSS} [%-5level] %msg%n
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss.SSS} %msg%n
 
-log4j.nl.tudelft.graphalytics=DEBUG
+log4j.category.org.thymeleaf=FATAL

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="OFF">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%-5level] %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="DEBUG">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="org.apache" level="OFF"/>
+        <Logger name="org.thymeleaf" level="OFF"/>
+    </Loggers>
+</Configuration>

--- a/src/main/scala/nl/tudelft/graphalytics/graphx/GraphXJob.scala
+++ b/src/main/scala/nl/tudelft/graphalytics/graphx/GraphXJob.scala
@@ -45,6 +45,8 @@ abstract class GraphXJob[VD : ClassTag, ED : ClassTag](graphVertexPath : String,
 		sparkConfiguration.setAppName(s"Graphalytics: $getAppName")
 		sparkConfiguration.setMaster("yarn-client")
 		sparkConfiguration.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+		sparkConfiguration.set("spark.ui.showConsoleProgress", "false")
+
 		val sparkContext = new SparkContext(sparkConfiguration)
 
 		// Load the raw graph data


### PR DESCRIPTION
Fix logging issue in the newest graphx implementation. Now graphalytics-core logs can be shown, while spark log is also enabled to facilitate debugging duration experiments.
